### PR TITLE
feat: watch group PDFs and forward processed file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ Send a message to a contact or group.
 
 ---
 
+### **POST /watch_pdf**
+Watch a specific group for incoming PDF files. When a PDF arrives it is
+processed via a local Python script and the result is sent to another
+contact/number.
+
+**Body:**
+```json
+{
+  "group": "My Group",
+  "forwardTo": "972501234567"
+}
+```
+
+**Notes:**
+- `group` can be group name or ID.
+- `forwardTo` can be a phone number or contact name.
+- The processing script is `process_pdf.py` which outputs the path of the
+  new file.
+
+---
+
 ## 📋 Parameters & Limitations
 | Parameter   | Type     | Required | Description |
 |-------------|----------|----------|-------------|

--- a/process_pdf.py
+++ b/process_pdf.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import sys, os, shutil
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: process_pdf.py <input_path>")
+        return 1
+    inp = sys.argv[1]
+    if not os.path.isfile(inp):
+        print(f"Input file not found: {inp}")
+        return 1
+    base = os.path.basename(inp)
+    out_path = os.path.join(os.path.dirname(inp), f"processed_{base}")
+    shutil.copyfile(inp, out_path)
+    print(out_path)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- watch a WhatsApp group for incoming PDF documents
- run local Python processing on the file and forward processed PDF to a target number
- document new `/watch_pdf` endpoint and add helper script

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./whatsapp-send');"`
- `python3 process_pdf.py` *(prints usage)*

------
https://chatgpt.com/codex/tasks/task_e_68b338d0e66c83298c16bb46bed6e7bf